### PR TITLE
Clarify active and passive web content

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -140,3 +140,7 @@ The diagram illustrates the data flow and interactions between core browser comp
   }
 }
 </pre>
+
+# Acknowledgment # {#acknowledgment}
+
+Several individuals contributed to the document. The editors especially thanks Anna Weine.

--- a/index.bs
+++ b/index.bs
@@ -26,7 +26,7 @@ Boilerplate: omit issues-index, omit conformance, repository-issue-tracking off
 
 The Web Platform is a collection of open (royalty-free) technologies that enable the Web. As a platform, users interact with websites using their user agent (e.g., a Web Browser).
 
-Websites contain a series of file formats, such as HTML, CSS, fonts, multimedia files, and scripts, that are transmitted from the server to the user's device, interpreted, and rendered by the browser so the user can use them.   
+Websites contain a series of file formats - passive content such as fonts, images, and multimedia, and active content such as HTML, JavaScript, and WebAssembly - that are transmitted from the server to the user's device and interpreted by the browser. Passive content is decoded and rendered; active content executes with the authority of its origin and constitutes the primary attack surface of the web. This distinction is useful, but not absolute: injected CSS can still become an attack surface, for example when selector matching and resource loads are used to infer or leak page state [[xsleaks-css-injection]].
 The web browser is a critical and widely used gateway for accessing the web. It is increasingly relied upon as the single most important application for work, forming the basis of browser-centric workflows.
 
 However, the Web Platform presents significant security and privacy challenges for the Web Browser, which is designed to request and execute instructions from arbitrary locations on the Internet, and it must surrender considerable control to web servers to render content correctly, as it runs code from untrusted sources.
@@ -131,3 +131,12 @@ The diagram illustrates the data flow and interactions between core browser comp
     <img src="images/DFD.svg">
     <figcaption>Data Flow Diagram (DFD)</figcaption>
 </figure>
+
+<pre class=biblio>
+{
+  "xsleaks-css-injection": {
+    "title": "CSS Injection",
+    "href": "https://xsleaks.dev/docs/attacks/css-injection/"
+  }
+}
+</pre>


### PR DESCRIPTION
This PR clarifies the initial description of web file formats by distinguishing passive content from active content.

Passive content, such as fonts, images, and multimedia, is decoded and rendered by the browser. Active content, such as HTML, JavaScript, and WebAssembly, executes with the authority of its origin and is a primary attack surface of the web.

Closes #10


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/threat-model-web/pull/18.html" title="Last updated on Jun 9, 2026, 12:53 PM UTC (ba2b022)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/threat-model-web/18/d1fa504...ba2b022.html" title="Last updated on Jun 9, 2026, 12:53 PM UTC (ba2b022)">Diff</a>